### PR TITLE
Refactored app to utilize lazy-loading

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,17 +3,13 @@ import { Nav, Platform } from 'ionic-angular';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 
-import { HomePage } from '../pages/home/home';
-import { DirectoryPage } from '../pages/directory/directory';
-import { LoginPage } from '../pages/login/login';
-
 @Component({
   templateUrl: 'app.html'
 })
 export class MyApp {
   @ViewChild(Nav) nav: Nav;
 
-  rootPage: any = HomePage;
+  rootPage: any = 'HomePage';
 
   pages: Array<{title: string, component: any}>;
 
@@ -22,9 +18,9 @@ export class MyApp {
 
     // used for an example of ngFor and navigation
     this.pages = [
-      { title: 'Home', component: HomePage },
-      { title: 'Directory', component: DirectoryPage },
-      { title: 'Login', component: LoginPage }
+      { title: 'Home', component: 'HomePage' },
+      { title: 'Directory', component: 'DirectoryPage' },
+      { title: 'Login', component: 'LoginPage' }
     ];
 
   }
@@ -41,7 +37,10 @@ export class MyApp {
   openPage(page) {
     // Reset the content nav to have just this page
     // we wouldn't want the back button to show in this scenario
-    if(page.title==='Home') this.nav.setRoot(page.component);
-    else this.nav.push(page.component);
+    if( page.title === 'Home') {
+      this.nav.setRoot(page.component);
+    } else {
+      this.nav.push(page.component);
+    }
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,37 +6,23 @@ import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 
 import { MyApp } from './app.component';
-import { HomePage } from '../pages/home/home';
-import { DirectoryPage } from '../pages/directory/directory';
-import { LoginPage } from '../pages/login/login';
 import { ComponentsModule } from '../components/components.module';
 import { PipesModule } from '../pipes/pipes.module';
-import { DirectoryDetailPage } from "../pages/directory-detail/directory-detail";
 import { ApiServiceProvider } from '../providers/api.service/api.service';
 import { ProfilesApi, ProfilesInjectionToken } from '../app/app-config';
 
 @NgModule({
   declarations: [
-    MyApp,
-    HomePage,
-    DirectoryPage,
-    LoginPage,
-    DirectoryDetailPage
+    MyApp
   ],
   imports: [
     BrowserModule,
     HttpModule,
     IonicModule.forRoot(MyApp),
-    ComponentsModule,
-    PipesModule
   ],
   bootstrap: [IonicApp],
   entryComponents: [
-    MyApp,
-    HomePage,
-    DirectoryPage,
-    LoginPage,
-    DirectoryDetailPage
+    MyApp
   ],
   providers: [
     StatusBar,

--- a/src/pages/directory-detail/directory-detail.module.ts
+++ b/src/pages/directory-detail/directory-detail.module.ts
@@ -1,13 +1,17 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
+
 import { DirectoryDetailPage } from './directory-detail';
 
 @NgModule({
   declarations: [
-    DirectoryDetailPage,
+    DirectoryDetailPage
   ],
   imports: [
-    IonicPageModule.forChild(DirectoryDetailPage),
+    IonicPageModule.forChild(DirectoryDetailPage)
   ],
+  exports: [
+    DirectoryDetailPage
+  ]
 })
 export class DirectoryDetailPageModule {}

--- a/src/pages/directory-detail/directory-detail.spec.ts
+++ b/src/pages/directory-detail/directory-detail.spec.ts
@@ -3,7 +3,6 @@ import { IonicModule, NavController, NavParams } from 'ionic-angular';
 import {
   NavMock,
   NavParamsMock,
-  SearchPipeMock,
   ApiServiceProviderMock
 } from '../../../test-config/mocks-ionic';
 import { DirectoryDetailPage } from './directory-detail';
@@ -14,7 +13,7 @@ describe('DirectoryDetailPage', () => {
     let component: DirectoryDetailPage;
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-          declarations: [ DirectoryDetailPage, SearchPipeMock ],
+          declarations: [ DirectoryDetailPage ],
           imports: [
             IonicModule.forRoot(DirectoryDetailPage)
           ],

--- a/src/pages/directory-detail/directory-detail.ts
+++ b/src/pages/directory-detail/directory-detail.ts
@@ -2,13 +2,6 @@ import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
 import { Profile } from '../../models/profile/profile';
 
-/**
- * Generated class for the DirectoryDetailPage page.
- *
- * See https://ionicframework.com/docs/components/#navigation for more info on
- * Ionic pages and navigation.
- */
-
 @IonicPage()
 @Component({
   selector: 'page-directory-detail',

--- a/src/pages/directory/directory.module.ts
+++ b/src/pages/directory/directory.module.ts
@@ -1,11 +1,19 @@
 import { NgModule } from '@angular/core';
-import { SearchPipe } from '../../pipes/search/search';
+import { IonicPageModule } from 'ionic-angular';
+
+import { DirectoryPage } from './directory';
+import { PipesModule } from '../../pipes/pipes.module';
 
 @NgModule({
   declarations: [
-    SearchPipe
+    DirectoryPage
   ],
   imports: [
+    IonicPageModule.forChild(DirectoryPage),
+    PipesModule
+  ],
+  exports: [
+    DirectoryPage
   ]
 })
 export class DirectoryPageModule {}

--- a/src/pages/directory/directory.ts
+++ b/src/pages/directory/directory.ts
@@ -2,14 +2,6 @@ import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
 import { ApiServiceProvider } from '../../providers/api.service/api.service';
 import { Profile, generateFullName } from '../../models/profile/profile';
-import { DirectoryDetailPage } from "../directory-detail/directory-detail";
-
-/**
- * Generated class for the DirectoryPage page.
- *
- * See https://ionicframework.com/docs/components/#navigation for more info on
- * Ionic pages and navigation.
- */
 
 @IonicPage()
 @Component({
@@ -34,7 +26,7 @@ export class DirectoryPage {
   }
 
   goToDirectoryDetail(profile){
-    this.navCtrl.push(DirectoryDetailPage, { profile: profile });
+    this.navCtrl.push('DirectoryDetailPage', { profile: profile });
   }
 
   getFullName(profile: Profile): string {

--- a/src/pages/home/home.module.ts
+++ b/src/pages/home/home.module.ts
@@ -1,9 +1,17 @@
 import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+
+import { HomePage } from './home';
 
 @NgModule({
   declarations: [
+    HomePage
   ],
   imports: [
+    IonicPageModule.forChild(HomePage)
   ],
+  exports: [
+    HomePage
+  ]
 })
 export class HomePageModule {}

--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -1,7 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { IonicModule, NavController, NavParams} from 'ionic-angular';
-import { DirectoryPage } from '../directory/directory';
-import { LoginPage } from '../login/login';
 
 import { HomePage } from './home';
 import {
@@ -39,7 +37,7 @@ describe('HomePage', () => {
         it('should open DirectoryPage', () => {
           spyOn(component.navCtrl, 'push');
           component.openDirectoryPage();
-          expect(component.navCtrl.push).toHaveBeenCalledWith(DirectoryPage);
+          expect(component.navCtrl.push).toHaveBeenCalledWith('DirectoryPage');
         });
       });
 
@@ -47,7 +45,7 @@ describe('HomePage', () => {
         it('should open LoginPage', () => {
           spyOn(component.navCtrl, 'push');
           component.openLoginPage();
-          expect(component.navCtrl.push).toHaveBeenCalledWith(LoginPage);
+          expect(component.navCtrl.push).toHaveBeenCalledWith('LoginPage');
         });
       });
 

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -1,14 +1,5 @@
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
-import { DirectoryPage } from '../directory/directory';
-import { LoginPage } from '../login/login'
-
-/**
- * Generated class for the HomePage page.
- *
- * See https://ionicframework.com/docs/components/#navigation for more info on
- * Ionic pages and navigation.
- */
 
 @IonicPage()
 @Component({
@@ -22,11 +13,11 @@ export class HomePage {
   }
 
   openDirectoryPage() {
-    this.navCtrl.push(DirectoryPage);
+    this.navCtrl.push('DirectoryPage');
   }
 
   openLoginPage() {
-    this.navCtrl.push(LoginPage);
+    this.navCtrl.push('LoginPage');
   }
 
   logoutUser(){

--- a/src/pages/login/login.html
+++ b/src/pages/login/login.html
@@ -1,9 +1,3 @@
-<!--
-  Generated template for the LoginPage page.
-
-  See http://ionicframework.com/docs/components/#navigation for more info on
-  Ionic pages and navigation.
--->
 <ion-header>
 
   <ion-navbar>

--- a/src/pages/login/login.module.ts
+++ b/src/pages/login/login.module.ts
@@ -1,10 +1,17 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
 
+import { LoginPage } from './login';
+
 @NgModule({
   declarations: [
+    LoginPage
   ],
   imports: [
+    IonicPageModule.forChild(LoginPage)
   ],
+  exports: [
+    LoginPage
+  ]
 })
 export class LoginPageModule {}

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -1,13 +1,6 @@
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
 
-/**
- * Generated class for the LoginPage page.
- *
- * See https://ionicframework.com/docs/components/#navigation for more info on
- * Ionic pages and navigation.
- */
-
 @IonicPage()
 @Component({
   selector: 'page-login',
@@ -17,9 +10,4 @@ export class LoginPage {
 
   constructor(public navCtrl: NavController, public navParams: NavParams) {
   }
-
-  ionViewDidLoad() {
-    console.log('ionViewDidLoad LoginPage');
-  }
-
 }

--- a/src/pipes/search/search.ts
+++ b/src/pipes/search/search.ts
@@ -1,10 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-/**
- * Generated class for the SearchPipe pipe.
- *
- * See https://angular.io/api/core/Pipe for more info on Angular Pipes.
- */
 @Pipe({
   name: 'search',
 })


### PR DESCRIPTION
Given that the Ionic CLI generates pretty much everything (pages, components, services, etc.) with their own separate modules, it makes sense to lazy load them to boost the app's performance. It's one of the "best practices" that Angular & Ionic talk a lot about, so no reason not to follow along.

Also, we're eventually going to have two "apps" within this repo: the main Excella Central app (which we're working on now) and the Admin UI. We'll lazy-load one or the other based on whether the logged-in user is an Admin or not, so it makes sense to follow the lazy-loading strategy all around.

Reference: http://blog.ionic.io/ionic-and-lazy-loading-pt-1/