### PR TITLE
Splash screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 log.txt
 *.sublime-project
 *.sublime-workspace
-.vscode/
 npm-debug.log*
 
 .idea/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "editor.formatOnSave": true,
+  "editor.formatOnType": true,
+  "editor.formatOnPaste": true,
+  "prettier.bracketSpacing": true,
+  "prettier.semi": true,
+  "prettier.singleQuote": true,
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+
+    // exclude .js and .js.map files, when in a TypeScript project
+    "**/*.js": { "when": "$(basename).ts" },
+    "**/*.js.map": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "typescript",
+            "tsconfig": "tsconfig.json",
+            "option": "watch",
+            "problemMatcher": [
+                "$tsc-watch"
+            ]
+        }
+    ]
+}

--- a/config.xml
+++ b/config.xml
@@ -83,4 +83,5 @@
     <plugin name="cordova-plugin-device" spec="^1.1.7" />
     <plugin name="cordova-plugin-splashscreen" spec="^4.1.0" />
     <plugin name="cordova-plugin-ionic-webview" spec="^1.1.16" />
+    <plugin name="cordova-sqlite-storage" spec="^2.1.2" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,6 +1765,19 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-whitelist/-/cordova-plugin-whitelist-1.3.3.tgz",
       "integrity": "sha1-tehezbv+Wu3tQKG/TuI3LmfZb7Q="
     },
+    "cordova-sqlite-storage": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cordova-sqlite-storage/-/cordova-sqlite-storage-2.1.2.tgz",
+      "integrity": "sha1-+zzMhC0Ij95VE7fTFgqIMZ+3LqQ=",
+      "requires": {
+        "cordova-sqlite-storage-dependencies": "1.0.4"
+      }
+    },
+    "cordova-sqlite-storage-dependencies": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cordova-sqlite-storage-dependencies/-/cordova-sqlite-storage-dependencies-1.0.4.tgz",
+      "integrity": "sha1-gnmvyNg7AWG/p92cIoqCf13YFF4="
+    },
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cordova-plugin-splashscreen": "^4.1.0",
     "cordova-plugin-statusbar": "git+https://github.com/apache/cordova-plugin-statusbar.git",
     "cordova-plugin-whitelist": "^1.3.3",
+    "cordova-sqlite-storage": "^2.1.2",
     "ionic-angular": "3.7.1",
     "ionic-plugin-keyboard": "^2.2.1",
     "ionicons": "3.0.0",
@@ -77,7 +78,8 @@
       "cordova-plugin-statusbar": {},
       "cordova-plugin-device": {},
       "cordova-plugin-splashscreen": {},
-      "cordova-plugin-ionic-webview": {}
+      "cordova-plugin-ionic-webview": {},
+      "cordova-sqlite-storage": {}
     }
   }
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,45 +1,60 @@
-import { async, TestBed } from '@angular/core/testing';
+import { async, TestBed, ComponentFixture } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { IonicModule, Platform } from 'ionic-angular';
-
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
+import { IonicStorageModule } from '@ionic/storage';
 
 import { MyApp } from './app.component';
 import {
   PlatformMock,
   StatusBarMock,
-  SplashScreenMock
+  SplashScreenMock,
+  ApiServiceProviderMock,
+  StorageMock
 } from '../../test-config/mocks-ionic';
+import { ApiServiceProvider } from '../providers/api.service/api.service';
 
 describe('MyApp Component', () => {
-  let fixture;
-  let component;
+  let fixture: ComponentFixture<MyApp>;
+  let component: MyApp;
+  let storage: Storage;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [MyApp],
-      imports: [
-        IonicModule.forRoot(MyApp)
-      ],
-      providers: [
-        { provide: StatusBar, useClass: StatusBarMock },
-        { provide: SplashScreen, useClass: SplashScreenMock },
-        { provide: Platform, useClass: PlatformMock }
-      ]
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        declarations: [MyApp],
+        imports: [IonicModule.forRoot(MyApp), IonicStorageModule.forRoot()],
+        providers: [
+          { provide: StatusBar, useClass: StatusBarMock },
+          { provide: SplashScreen, useClass: SplashScreenMock },
+          { provide: Platform, useClass: PlatformMock },
+          { provide: ApiServiceProvider, useClass: ApiServiceProviderMock },
+          { provide: Storage, useClass: StorageMock }
+        ],
+        schemas: [NO_ERRORS_SCHEMA]
+      });
+      fixture = TestBed.createComponent(MyApp);
+      component = fixture.componentInstance;
+      storage = fixture.debugElement.injector.get(Storage);
     })
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(MyApp);
-    component = fixture.componentInstance;
-  });
+  );
 
   it('should be created', () => {
+    loadHomePageMock(storage);
     expect(component instanceof MyApp).toBe(true);
   });
 
-  it('should have three pages', () => {
-    expect(component.pages.length).toBe(3);
+  it('should have two pages', () => {
+    loadHomePageMock(storage);
+    expect(component.pages.length).toBe(2);
   });
-
 });
+
+export function loadLandingPageMock(storage: Storage) {
+  return spyOn(storage, 'get').and.returnValue(Promise.resolve(true));
+}
+
+export function loadHomePageMock(storage: Storage) {
+  return spyOn(storage, 'get').and.returnValue(Promise.resolve(false));
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,7 @@ export class MyApp {
   @ViewChild(Nav) nav: Nav;
   pages: Array<{ title: string; component: any }>;
   rootPage: any;
+  rememberUser: boolean;
 
   constructor(
     public platform: Platform,
@@ -21,6 +22,7 @@ export class MyApp {
     public storage: Storage
   ) {
     this.storage.get('rememberUser').then(rememberUser => {
+      this.rememberUser = rememberUser;
       if (rememberUser) {
         this.rootPage = 'HomePage';
       } else {
@@ -44,7 +46,7 @@ export class MyApp {
   }
 
   openPage(page) {
-    if (page.title === 'Landing') {
+    if (page.title === 'Landing' || page.title === 'Home') {
       this.nav.setRoot(page.component);
     } else {
       this.nav.push(page.component);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,45 +2,57 @@ import { Component, ViewChild } from '@angular/core';
 import { Nav, Platform } from 'ionic-angular';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
+import { ApiServiceProvider } from '../providers/api.service/api.service';
+import { Storage } from '@ionic/storage';
 
 @Component({
   templateUrl: 'app.html'
 })
 export class MyApp {
   @ViewChild(Nav) nav: Nav;
+  pages: Array<{ title: string; component: any }>;
+  rootPage: any;
 
-  rootPage: any = 'HomePage';
+  constructor(
+    public platform: Platform,
+    public statusBar: StatusBar,
+    public splashScreen: SplashScreen,
+    public apiServiceProvider: ApiServiceProvider,
+    public storage: Storage
+  ) {
+    this.storage.get('rememberUser').then(rememberUser => {
+      if (rememberUser) {
+        this.rootPage = 'HomePage';
+      } else {
+        this.rootPage = 'LandingPage';
+      }
+    });
 
-  pages: Array<{ title: string, component: any }>;
-
-  constructor(public platform: Platform, public statusBar: StatusBar, public splashScreen: SplashScreen) {
     this.initializeApp();
 
-    // used for an example of ngFor and navigation
     this.pages = [
       { title: 'Home', component: 'HomePage' },
-      { title: 'Directory', component: 'DirectoryPage' },
-      { title: 'Login', component: 'LoginPage' }
+      { title: 'Directory', component: 'DirectoryPage' }
     ];
-
   }
 
   initializeApp() {
     this.platform.ready().then(() => {
-      // Okay, so the platform is ready and our plugins are available.
-      // Here you can do any higher level native things you might need.
       this.statusBar.styleDefault();
       this.splashScreen.hide();
     });
   }
 
   openPage(page) {
-    // Reset the content nav to have just this page
-    // we wouldn't want the back button to show in this scenario
-    if (page.title === 'Home') {
+    if (page.title === 'Landing') {
       this.nav.setRoot(page.component);
     } else {
       this.nav.push(page.component);
     }
+  }
+
+  logout() {
+    this.apiServiceProvider.logout();
+    this.nav.setRoot('LandingPage');
   }
 }

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -10,6 +10,7 @@
       <button menuClose ion-item *ngFor="let p of pages" (click)="openPage(p)">
         {{p.title}}
       </button>
+      <button menuClose ion-item (click)="logout()">Logout</button>
     </ion-list>
   </ion-content>
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,6 +4,7 @@ import { HttpModule } from '@angular/http';
 import { IonicApp, IonicErrorHandler, IonicModule } from 'ionic-angular';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
+import { IonicStorageModule } from '@ionic/storage';
 
 import { MyApp } from './app.component';
 import { ApiServiceProvider } from '../providers/api.service/api.service';
@@ -19,6 +20,7 @@ import { HttpClientModule } from "@angular/common/http";
     HttpModule,
     HttpClientModule,
     IonicModule.forRoot(MyApp),
+    IonicStorageModule.forRoot()
   ],
   bootstrap: [IonicApp],
   entryComponents: [

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -1,10 +1,3 @@
-<!--
-  Generated template for the HomePage page.
-
-  See http://ionicframework.com/docs/components/#navigation for more info on
-  Ionic pages and navigation.
--->
-
 <ion-header>
   <ion-navbar>
     <button ion-button menuToggle>
@@ -18,8 +11,6 @@
 
 <ion-content padding>
   <h3>Excella Central</h3>
-  <button class="main-button" *ngIf="!loggedIn" ion-button color="primary" (click)="openLoginPage()">Login</button>
-  <br />
   <button class="main-button" ion-button color="primary" outline (click)="openDirectoryPage()">View Directory</button>
   <br />
   <button *ngIf="loggedIn" ion-button (click)="logoutUser()">Logout</button>

--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -1,60 +1,48 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule, NavController, NavParams} from 'ionic-angular';
+import { IonicModule, NavController, NavParams } from 'ionic-angular';
 
 import { HomePage } from './home';
-import {
-  NavMock,
-  NavParamsMock
-} from '../../../test-config/mocks-ionic';
+import { NavMock, NavParamsMock } from '../../../test-config/mocks-ionic';
 
 describe('HomePage', () => {
-    let component: HomePage;
-    let fixture: ComponentFixture<HomePage>;
+  let component: HomePage;
+  let fixture: ComponentFixture<HomePage>;
 
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-          declarations: [HomePage],
-          imports: [
-            IonicModule.forRoot(HomePage)
-          ],
-          providers: [
-            { provide: NavController, useClass: NavMock},
-            { provide: NavParams, useClass: NavParamsMock}
-          ]
-        });
-      }));
-
-      beforeEach(() => {
-        fixture = TestBed.createComponent(HomePage);
-        component = fixture.componentInstance;
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        declarations: [HomePage],
+        imports: [IonicModule.forRoot(HomePage)],
+        providers: [
+          { provide: NavController, useClass: NavMock },
+          { provide: NavParams, useClass: NavParamsMock }
+        ]
       });
+    })
+  );
 
-      it('should be created', () => {
-        expect(component).toBeDefined();
-      });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HomePage);
+    component = fixture.componentInstance;
+  });
 
-      describe('openDirectoryPage', () => {
-        it('should open DirectoryPage', () => {
-          spyOn(component.navCtrl, 'push');
-          component.openDirectoryPage();
-          expect(component.navCtrl.push).toHaveBeenCalledWith('DirectoryPage');
-        });
-      });
+  it('should be created', () => {
+    expect(component).toBeDefined();
+  });
 
-      describe('openLoginPage', () => {
-        it('should open LoginPage', () => {
-          spyOn(component.navCtrl, 'push');
-          component.openLoginPage();
-          expect(component.navCtrl.push).toHaveBeenCalledWith('LoginPage');
-        });
-      });
+  describe('openDirectoryPage', () => {
+    it('should open DirectoryPage', () => {
+      spyOn(component.navCtrl, 'push');
+      component.openDirectoryPage();
+      expect(component.navCtrl.push).toHaveBeenCalledWith('DirectoryPage');
+    });
+  });
 
-      describe('logoutUser', () => {
-        it('should log out user', () => {
-          component.loggedIn = true;
-          component.logoutUser();
-          expect(component.loggedIn).toBe(false);
-        });
-      });
-
+  describe('logoutUser', () => {
+    it('should log out user', () => {
+      component.loggedIn = true;
+      component.logoutUser();
+      expect(component.loggedIn).toBe(false);
+    });
+  });
 });

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -16,10 +16,6 @@ export class HomePage {
     this.navCtrl.push('DirectoryPage');
   }
 
-  openLoginPage() {
-    this.navCtrl.push('LoginPage');
-  }
-
   logoutUser() {
     console.log("User logged out");
     this.loggedIn = false;

--- a/src/pages/landing/landing.html
+++ b/src/pages/landing/landing.html
@@ -1,0 +1,5 @@
+<ion-content padding>
+  <h3>Welcome to Excella Central</h3>
+  <button class="main-button" ion-button color="primary" (click)="openLoginPage()">Login</button>
+  <button class="main-button" ion-button color="primary" outline>Register</button>
+</ion-content>

--- a/src/pages/landing/landing.module.ts
+++ b/src/pages/landing/landing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { LandingPage } from './landing';
+
+@NgModule({
+  declarations: [
+    LandingPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(LandingPage),
+  ],
+})
+export class LandingPageModule {}

--- a/src/pages/landing/landing.scss
+++ b/src/pages/landing/landing.scss
@@ -1,0 +1,11 @@
+ion-content{
+  text-align:center;
+  h3{
+    margin-top:35px !important;
+  }
+  button.main-button{
+    width:calc(100% - 60px);
+    max-width:800px;
+    margin:10px 0 !important;
+  }
+}

--- a/src/pages/landing/landing.spec.ts
+++ b/src/pages/landing/landing.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { IonicModule, NavController, NavParams } from 'ionic-angular';
+import { By } from '@angular/platform-browser';
+import { NavMock, NavParamsMock } from '../../../test-config/mocks-ionic';
+import { LandingPage } from './landing';
+
+describe('LandingPage', () => {
+  let fixture: ComponentFixture<LandingPage>;
+  let component: LandingPage;
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        declarations: [LandingPage],
+        imports: [IonicModule.forRoot(LandingPage)],
+        providers: [
+          { provide: NavController, useClass: NavMock },
+          { provide: NavParams, useClass: NavParamsMock }
+        ]
+      });
+      fixture = TestBed.createComponent(LandingPage);
+      component = fixture.componentInstance;
+    })
+  );
+
+  it('should be created', () => {
+    expect(component).toBeDefined();
+  });
+});

--- a/src/pages/landing/landing.ts
+++ b/src/pages/landing/landing.ts
@@ -4,12 +4,10 @@ import { IonicPage, NavController, NavParams } from 'ionic-angular';
 @IonicPage()
 @Component({
   selector: 'page-landing',
-  templateUrl: 'landing.html',
+  templateUrl: 'landing.html'
 })
 export class LandingPage {
-
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
-  }
+  constructor(public navCtrl: NavController, public navParams: NavParams) {}
 
   openLoginPage(): void {
     this.navCtrl.push('LoginPage');

--- a/src/pages/landing/landing.ts
+++ b/src/pages/landing/landing.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavController, NavParams } from 'ionic-angular';
+
+@IonicPage()
+@Component({
+  selector: 'page-landing',
+  templateUrl: 'landing.html',
+})
+export class LandingPage {
+
+  constructor(public navCtrl: NavController, public navParams: NavParams) {
+  }
+
+  openLoginPage(): void {
+    this.navCtrl.push('LoginPage');
+  }
+}

--- a/src/pages/login/login.spec.ts
+++ b/src/pages/login/login.spec.ts
@@ -1,35 +1,43 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule, NavController, NavParams} from 'ionic-angular';
-import { NavMock, NavParamsMock } from '../../../test-config/mocks-ionic';
+import { IonicModule, NavController, NavParams } from 'ionic-angular';
+import {
+  NavMock,
+  NavParamsMock,
+  StorageMock
+} from '../../../test-config/mocks-ionic';
 import { LoginPage } from './login';
-import {HttpModule} from "@angular/http";
-import {LoginApi, LoginInjectionToken, ProfilesApi, ProfilesInjectionToken} from "../../app/app-config";
+import { HttpModule } from '@angular/http';
+import {
+  LoginApi,
+  LoginInjectionToken,
+  ProfilesApi,
+  ProfilesInjectionToken
+} from '../../app/app-config';
+import { Storage } from '@ionic/storage/es2015/storage';
 
 describe('LoginPage', () => {
-    let fixture: ComponentFixture<LoginPage>;
-    let component: LoginPage;
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-          declarations: [LoginPage],
-          imports: [
-            IonicModule.forRoot(LoginPage),
-            HttpModule
-          ],
-          providers: [
-            { provide: NavController, useClass: NavMock},
-            { provide: NavParams, useClass: NavParamsMock},
-            { provide: ProfilesInjectionToken, useValue: ProfilesApi },
-            { provide: LoginInjectionToken, useValue: LoginApi }
-          ]
-        });
-      }));
-
-      beforeEach(() => {
-        fixture = TestBed.createComponent(LoginPage);
-        component = fixture.componentInstance;
+  let fixture: ComponentFixture<LoginPage>;
+  let component: LoginPage;
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        declarations: [LoginPage],
+        imports: [IonicModule.forRoot(LoginPage), HttpModule],
+        providers: [
+          { provide: NavController, useClass: NavMock },
+          { provide: NavParams, useClass: NavParamsMock },
+          { provide: ProfilesInjectionToken, useValue: ProfilesApi },
+          { provide: LoginInjectionToken, useValue: LoginApi },
+          { provide: Storage, useClass: StorageMock }
+        ]
       });
 
-      it('should be created', () => {
-        expect(component).toBeDefined();
-      });
+      fixture = TestBed.createComponent(LoginPage);
+      component = fixture.componentInstance;
+    })
+  );
+
+  it('should be created', () => {
+    expect(component).toBeDefined();
+  });
 });

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -1,19 +1,23 @@
 import { Component } from '@angular/core';
 import { IonicPage, NavController } from 'ionic-angular';
-import { FormBuilder, FormGroup, Validators } from "@angular/forms";
-import { ApiServiceProvider } from "../../providers/api.service/api.service";
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ApiServiceProvider } from '../../providers/api.service/api.service';
 
 @IonicPage()
 @Component({
   selector: 'page-login',
   providers: [ApiServiceProvider],
-  templateUrl: 'login.html',
+  templateUrl: 'login.html'
 })
 export class LoginPage {
   private userForm: FormGroup;
 
-  constructor(public navCtrl: NavController, private formBuilder: FormBuilder, private apiServiceProvider: ApiServiceProvider) {
-
+  constructor(
+    /*public toastCtrl: ToastController, */
+    private navCtrl: NavController,
+    private formBuilder: FormBuilder,
+    private apiServiceProvider: ApiServiceProvider
+  ) {
     this.userForm = this.formBuilder.group({
       username: ['', Validators.required],
       password: ['', [Validators.required, Validators.minLength(6)]]
@@ -21,9 +25,7 @@ export class LoginPage {
   }
 
   loginUser() {
-
-
-    this.apiServiceProvider.checkLogin(
+    this.apiServiceProvider.login(
       this.userForm.value.username,
       this.userForm.value.password,
       this.handleLogin.bind(this)
@@ -34,9 +36,8 @@ export class LoginPage {
     if (isValid) {
       // save login credentials
       console.log('valid login');
-      this.navCtrl.push('HomePage');
+      this.navCtrl.setRoot('HomePage');
     } else {
-      // this.navCtrl.push('SplashScreen');
       console.log('invalid login');
       //TODO: find out why toastCtrl .present() causes tests to fail
       /*

--- a/src/providers/api.service/api.service.spec.ts
+++ b/src/providers/api.service/api.service.spec.ts
@@ -1,50 +1,65 @@
-import {TestBed, inject} from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import {
   HttpModule,
   Response,
   ResponseOptions,
   XHRBackend
 } from '@angular/http';
-import {MockBackend} from '@angular/http/testing';
-import {ApiServiceProvider} from '../api.service/api.service';
-import {LoginInjectionToken, ProfilesInjectionToken} from '../../app/app-config';
-import {Profile} from '../../models/profile/profile';
+import { MockBackend } from '@angular/http/testing';
+import { ApiServiceProvider } from '../api.service/api.service';
+import {
+  LoginInjectionToken,
+  ProfilesInjectionToken
+} from '../../app/app-config';
+import { Profile } from '../../models/profile/profile';
+import { StorageMock } from '../../../test-config/mocks-ionic';
+import { IonicStorageModule } from '@ionic/storage';
 
 describe('ApiServiceProvider', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpModule],
+      imports: [HttpModule, IonicStorageModule.forRoot()],
       providers: [
         ApiServiceProvider,
-        {provide: XHRBackend, useClass: MockBackend},
-        {provide: ProfilesInjectionToken, useValue: ''},
-        {provide: LoginInjectionToken, useValue: ''}
+        { provide: XHRBackend, useClass: MockBackend },
+        { provide: ProfilesInjectionToken, useValue: '' },
+        { provide: LoginInjectionToken, useValue: '' },
+        { provide: Storage, useClass: StorageMock }
       ]
     });
   });
 
   describe('getProfiles', () => {
-    it('should return a promise with an array of profiles',
-      inject([ApiServiceProvider, XHRBackend], (apiServiceProvider, mockBackend) => {
-        const mockResponse = [
-          this.createMockProfile("0"),
-          this.createMockProfile("1"),
-          this.createMockProfile("2"),
-          this.createMockProfile("3"),
-        ];
-        mockBackend.connections.subscribe((connection) => {
-          connection.mockRespond(new Response(new ResponseOptions({
-            body: JSON.stringify(mockResponse)
-          })));
-        });
-        apiServiceProvider.getProfiles().then((profiles) => {
-          expect(profiles.length).toBe(4);
-          expect(profiles[0].firstName).toEqual('Profile 0');
-          expect(profiles[1].firstName).toEqual('Profile 1');
-          expect(profiles[2].firstName).toEqual('Profile 2');
-          expect(profiles[3].firstName).toEqual('Profile 3');
-        });
-      }));
+    it(
+      'should return a promise with an array of profiles',
+      inject(
+        [ApiServiceProvider, XHRBackend],
+        (apiServiceProvider, mockBackend) => {
+          const mockResponse = [
+            this.createMockProfile('0'),
+            this.createMockProfile('1'),
+            this.createMockProfile('2'),
+            this.createMockProfile('3')
+          ];
+          mockBackend.connections.subscribe(connection => {
+            connection.mockRespond(
+              new Response(
+                new ResponseOptions({
+                  body: JSON.stringify(mockResponse)
+                })
+              )
+            );
+          });
+          apiServiceProvider.getProfiles().then(profiles => {
+            expect(profiles.length).toBe(4);
+            expect(profiles[0].firstName).toEqual('Profile 0');
+            expect(profiles[1].firstName).toEqual('Profile 1');
+            expect(profiles[2].firstName).toEqual('Profile 2');
+            expect(profiles[3].firstName).toEqual('Profile 3');
+          });
+        }
+      )
+    );
   });
 });
 

--- a/src/providers/api.service/api.service.ts
+++ b/src/providers/api.service/api.service.ts
@@ -2,15 +2,21 @@ import { Injectable, Inject } from '@angular/core';
 import { Http } from '@angular/http';
 import 'rxjs/add/operator/map';
 import { Profile } from '../../models/profile/profile';
-import { ConnectionString, LoginInjectionToken, ProfilesInjectionToken } from '../../app/app-config';
-
+import {
+  ConnectionString,
+  LoginInjectionToken,
+  ProfilesInjectionToken
+} from '../../app/app-config';
+import { Storage } from '@ionic/storage';
 
 @Injectable()
 export class ApiServiceProvider {
-  constructor(public http: Http,
-              @Inject(ProfilesInjectionToken) public profilesApi: ConnectionString,
-              @Inject(LoginInjectionToken) public loginApi: ConnectionString) {
-  }
+  constructor(
+    public http: Http,
+    private storage: Storage,
+    @Inject(ProfilesInjectionToken) public profilesApi: ConnectionString,
+    @Inject(LoginInjectionToken) public loginApi: ConnectionString
+  ) {}
 
   async getProfiles(): Promise<Profile[]> {
     let profiles = [];
@@ -30,11 +36,14 @@ export class ApiServiceProvider {
     return profiles;
   }
 
-  checkLogin(username: String, password: String, loginCallback) {
-    this.http.post(this.loginApi.url, { username: username, password: password })
-      .subscribe(data => {
+  login(username: string, password: string, loginCallback) {
+    this.http
+      .post(this.loginApi.url, { username: username, password: password })
+      .subscribe(
+        data => {
           //handle login
           loginCallback(true);
+          this.storage.set('rememberUser', true);
         },
         // this call will always 404 right now, so just hack it together
         err => {
@@ -43,6 +52,11 @@ export class ApiServiceProvider {
           } else {
             loginCallback(false);
           }
-        });
+        }
+      );
+  }
+
+  logout() {
+    this.storage.set('rememberUser', false);
   }
 }

--- a/src/providers/api.service/api.service.ts
+++ b/src/providers/api.service/api.service.ts
@@ -49,6 +49,7 @@ export class ApiServiceProvider {
         err => {
           if (username === 'login') {
             loginCallback(true);
+            this.storage.set('rememberUser', true);
           } else {
             loginCallback(false);
           }

--- a/test-config/mocks-ionic.ts
+++ b/test-config/mocks-ionic.ts
@@ -5,7 +5,7 @@ import { Profile } from '../src/models/profile/profile';
 
 export class PlatformMock {
   public ready(): Promise<string> {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       resolve('READY');
     });
   }
@@ -15,7 +15,7 @@ export class PlatformMock {
   }
 
   public registerBackButtonAction(fn: Function, priority?: number): Function {
-    return (() => true);
+    return () => true;
   }
 
   public hasFocus(ele: HTMLElement): boolean {
@@ -35,7 +35,7 @@ export class PlatformMock {
       paddingLeft: '10',
       paddingTop: '10',
       paddingRight: '10',
-      paddingBottom: '10',
+      paddingBottom: '10'
     };
   }
 
@@ -43,8 +43,12 @@ export class PlatformMock {
     return callback;
   }
 
-  public registerListener(ele: any, eventName: string, callback: any): Function {
-    return (() => true);
+  public registerListener(
+    ele: any,
+    eventName: string,
+    callback: any
+  ): Function {
+    return () => true;
   }
 
   public win(): Window {
@@ -81,24 +85,23 @@ export class SplashScreenMock extends SplashScreen {
 }
 
 export class NavMock {
-
   public pop(): any {
-    return new Promise(function (resolve: Function): void {
+    return new Promise(function(resolve: Function): void {
       resolve();
     });
   }
 
   public push(): any {
-    return new Promise(function (resolve: Function): void {
+    return new Promise(function(resolve: Function): void {
       resolve();
     });
   }
 
   public getActive(): any {
     return {
-      'instance': {
-        'model': 'something',
-      },
+      instance: {
+        model: 'something'
+      }
     };
   }
 
@@ -109,7 +112,6 @@ export class NavMock {
   public registerChildNav(nav: any): void {
     return;
   }
-
 }
 
 export class NavParamsMock {
@@ -123,18 +125,20 @@ export class NavParamsMock {
 @Pipe({ name: 'search' })
 export class SearchPipeMock implements PipeTransform {
   transform(value: number): number {
-    //Do stuff here, if you want
     return value;
   }
 }
 
 export class ApiServiceProviderMock {
   getProfiles() {
-    return new Promise<Profile[]>((resolve, reject) => {
-    });
+    return new Promise<Profile[]>((resolve, reject) => {});
   }
 }
 
-export class DeepLinkerMock {
-
+export class StorageMock {
+  get(param) {
+    new Promise((resolve, reject) => {});
+  }
 }
+
+export class DeepLinkerMock {}


### PR DESCRIPTION
- When app launches, user see's splash screen (Login or Register)
- User can login (using username of "login")
- Local storage sets `rememberUser` to true so user doesn't have to log back in every time they re-open the app
- User then sees Home page
- Logout button is visible in sidemenu (which sets `rememberUser` to false and re-routes to splash screen)

Also, the `.vscode/settings.json` file now enforces "Prettier" code formatting on-save for each file